### PR TITLE
chore(android): remove jcenter repository

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -94,7 +94,6 @@ rootProject.allprojects {
   repositories {
     mavenCentral()
     google()
-    jcenter()
     maven { url = uri("https://us-central1-maven.pkg.dev/verisoul/android") }
   }
   }

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -16,7 +16,7 @@ target 'VerisoulReactnativeExample' do
   config = use_native_modules!
   
   # VerisoulSDK from GitHub
-  pod 'VerisoulSDK', :git => 'https://github.com/verisoul/ios-sdk.git', :tag => '0.4.64'
+  pod 'VerisoulSDK', :git => 'https://github.com/verisoul/ios-sdk.git', :tag => '0.4.65'
 
   use_react_native!(
     :path => config[:reactNativePath],

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1500,7 +1500,7 @@ PODS:
     - React-perflogger (= 0.77.0)
     - React-utils (= 0.77.0)
   - SocketRocket (0.7.1)
-  - verisoul-reactnative (0.4.63):
+  - verisoul-reactnative (0.4.65):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1520,9 +1520,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - VerisoulSDK (= 0.4.64)
+    - VerisoulSDK (= 0.4.65)
     - Yoga
-  - VerisoulSDK (0.4.64)
+  - VerisoulSDK (0.4.65)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -1594,7 +1594,7 @@ DEPENDENCIES:
   - ReactCodegen (from `build/generated/ios`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - verisoul-reactnative (from `../..`)
-  - VerisoulSDK (from `https://github.com/verisoul/ios-sdk.git`, tag `0.4.64`)
+  - VerisoulSDK (from `https://github.com/verisoul/ios-sdk.git`, tag `0.4.65`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -1737,14 +1737,14 @@ EXTERNAL SOURCES:
     :path: "../.."
   VerisoulSDK:
     :git: https://github.com/verisoul/ios-sdk.git
-    :tag: 0.4.64
+    :tag: 0.4.65
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 CHECKOUT OPTIONS:
   VerisoulSDK:
     :git: https://github.com/verisoul/ios-sdk.git
-    :tag: 0.4.64
+    :tag: 0.4.65
 
 SPEC CHECKSUMS:
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
@@ -1813,10 +1813,10 @@ SPEC CHECKSUMS:
   ReactCodegen: 58a974a1a86362975fd49596480c5f0f17ee06a2
   ReactCommon: e686c5766f0ebe5293be5a3957b833645cdac8ad
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  verisoul-reactnative: 27dcd26fc26ef1275dd87e3fbca4c8875b20f665
-  VerisoulSDK: 61296c96e33bb2cec1ebf880147296dabc8f739e
+  verisoul-reactnative: 9c1dd543f22666a15ea44f70d60cf077c8bba92d
+  VerisoulSDK: cb64c8e609dd32c2ce29d36881a8d60569cc59ac
   Yoga: c34725819ab0a5962e85455b9e56679b306910ee
 
-PODFILE CHECKSUM: 1a2fbdc0fbf825fcd97424301431897a1f7a861a
+PODFILE CHECKSUM: 4cfa36f2cfb597e56608b172c971270efdc8d664
 
 COCOAPODS: 1.15.2

--- a/verisoul-reactnative.podspec
+++ b/verisoul-reactnative.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/verisoul/react-native-sdk", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
-  s.dependency 'VerisoulSDK', '0.4.64'
+  s.dependency 'VerisoulSDK', '0.4.65'
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.


### PR DESCRIPTION
## Summary
- Remove deprecated `jcenter()` from the React Native wrapper's Android Gradle repositories.

## Test plan
- `yarn install`
- `yarn plugin:build`
- RN example: `cd example/android && ./gradlew :app:assembleDebug --no-daemon --console=plain`
- Expo example: `cd example-expo && npm ci && npm run prebuild -- --platform android && cd android && ./gradlew :app:assembleDebug --no-daemon --console=plain`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency/repository maintenance changes, but could affect mobile builds if any transitive artifact was previously resolved only via `jcenter()` or if the VerisoulSDK bump introduces breaking changes.
> 
> **Overview**
> Removes the deprecated `jcenter()` repository from the Android Gradle project repository list.
> 
> Bumps the iOS `VerisoulSDK` dependency from `0.4.64` to `0.4.65` in both the example app `Podfile`/`Podfile.lock` and the library `verisoul-reactnative.podspec`, updating lockfile checksums accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c392e3a24618690040997f60a46ed31a5c609fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->