### PR TITLE
fix: include plugin/build in published npm package

### DIFF
--- a/plugin/.npmignore
+++ b/plugin/.npmignore
@@ -1,0 +1,4 @@
+node_modules/
+*.log
+.DS_Store
+src/


### PR DESCRIPTION
## Summary

- The `plugin/.gitignore` excluded `build/`, which caused `npm pack` to omit the `plugin/build/` directory from the published tarball — even though it was listed in the `package.json` `files` array. This broke `expo prebuild` with `Error: Cannot find module './plugin/build/index'`.
- Adds a `plugin/.npmignore` that overrides the `.gitignore` for npm packing, ensuring the compiled Expo config plugin ships with the package.

Fixes #17

## Verification

Before fix — `npm pack --dry-run` shows only `app.plugin.js`, no `plugin/build/*` files.

After fix — `npm pack --dry-run` includes all `plugin/build/*.js` and `plugin/build/*.d.ts` files.


Made with [Cursor](https://cursor.com)