### PR TITLE
Add SDK size to System Requirements in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ _To run the SDK a Verisoul Project ID is required._ Schedule a call [here](https
 - iOS 14.0 or higher
 - Android API level 21 (Android 5.0) or higher
 - For Expo projects: Expo SDK 45 or higher with custom development client
+- SDK Size: ~90 KB (plus native iOS and Android SDK dependencies)
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- Adds SDK size (~90 KB + native deps) to the System Requirements section of the README

## Test plan
- [ ] Verify README renders correctly on GitHub

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no code or runtime behavior is modified.
> 
> **Overview**
> Adds the SDK’s approximate size ("~90 KB" plus native iOS/Android dependencies) to the **System Requirements** section of `README.md` to better set integration expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc3fda46b8ff1b3ce57629422131e62f1c13fe5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->