### PR TITLE
chore: release 0.4.68 (bump native android 0.4.69, ios 0.4.68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.4.68] - 2026-06-25
+
+### Changed
+- **Android**: bump `ai.verisoul:android` to **0.4.69** (env-specific WebView host + JS bridge validation)
+- **iOS**: bump `VerisoulSDK` to **0.4.68** (env-specific WebView host)
+
 ## [0.4.65] - 2026-01-23
 
 ### Changed

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -104,7 +104,7 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  api "ai.verisoul:android:0.4.66"
+  api "ai.verisoul:android:0.4.69"
 
   // Unit test dependencies for deadlock demonstration tests
   testImplementation "junit:junit:4.13.2"

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -16,7 +16,7 @@ target 'VerisoulReactnativeExample' do
   config = use_native_modules!
   
   # VerisoulSDK from GitHub
-  pod 'VerisoulSDK', :git => 'https://github.com/verisoul/ios-sdk.git', :tag => '0.4.65'
+  pod 'VerisoulSDK', :git => 'https://github.com/verisoul/ios-sdk.git', :tag => '0.4.68'
 
   use_react_native!(
     :path => config[:reactNativePath],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verisoul_ai/react-native-verisoul",
-  "version": "0.4.67",
+  "version": "0.4.68",
   "description": "Verisoul helps businesses stop fake accounts and fraud",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/verisoul-reactnative.podspec
+++ b/verisoul-reactnative.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/verisoul/react-native-sdk", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
-  s.dependency 'VerisoulSDK', '0.4.65'
+  s.dependency 'VerisoulSDK', '0.4.68'
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.


### PR DESCRIPTION
## Summary
- Bump pinned native Android SDK to `0.4.69` and native iOS `VerisoulSDK` to `0.4.68` (env-specific WebView host routing + Android JS bridge validation fix).
- Update example iOS Podfile tag to `0.4.68`.
- Release wrapper version `0.4.68`.

## Test plan
- [x] CI: yarn prepare/test/lint/typecheck
- [x] Underlying native artifacts validated on prod (native Android + iOS, and Flutter Android wrapper): Repeat 30/30, Chaos 40/40, every returned session_id authenticates 200

Made with [Cursor](https://cursor.com)