### PR TITLE
chore: release 0.4.69 (native cross-project session fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.4.69] - 2026-06-26
+
+### Changed
+- **Android**: bump `ai.verisoul:android` to **0.4.70** (clear cached session on project/environment change)
+- **iOS**: bump `VerisoulSDK` to **0.4.69**
+
 ## [0.4.68] - 2026-06-25
 
 ### Changed

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -104,7 +104,7 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  api "ai.verisoul:android:0.4.69"
+  api "ai.verisoul:android:0.4.70"
 
   // Unit test dependencies for deadlock demonstration tests
   testImplementation "junit:junit:4.13.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verisoul_ai/react-native-verisoul",
-  "version": "0.4.68",
+  "version": "0.4.69",
   "description": "Verisoul helps businesses stop fake accounts and fraud",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/verisoul-reactnative.podspec
+++ b/verisoul-reactnative.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/verisoul/react-native-sdk", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
-  s.dependency 'VerisoulSDK', '0.4.68'
+  s.dependency 'VerisoulSDK', '0.4.69'
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.


### PR DESCRIPTION
## Summary
- Bumps native pins to pick up the cross-project/environment stale session fix:
  - `ai.verisoul:android` 0.4.69 → **0.4.70**
  - `VerisoulSDK` (iOS) 0.4.68 → **0.4.69**
- Bumps package version to **0.4.69**.

## Test plan
- [x] RN example Android builds against `ai.verisoul:android:0.4.70` (resolves from Artifact Registry, native module compiles)
- [x] CI: test / lint / typecheck / build run on publish

Made with [Cursor](https://cursor.com)