### PR TITLE
chore: release 0.4.71 with native iOS Fabric view-theft crash fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.4.71] - 2026-07-07
+
+### Changed
+- **iOS**: bump `VerisoulSDK` to **0.4.70** — fixes a crash in React Native New Architecture (Fabric) apps where the SDK's touch-capture overlay cleanup could remove a React-managed view (tag collision), corrupting Fabric's mounting state and crashing with `NSRangeException` in `unmountChildComponentView` during view teardown
+
 ## [0.4.70] - 2026-07-06
 
 ### Fixed

--- a/example-expo/package-lock.json
+++ b/example-expo/package-lock.json
@@ -28,7 +28,7 @@
     },
     "..": {
       "name": "@verisoul_ai/react-native-verisoul",
-      "version": "0.4.70",
+      "version": "0.4.71",
       "license": "MIT",
       "workspaces": [
         "example"

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -16,7 +16,7 @@ target 'VerisoulReactnativeExample' do
   config = use_native_modules!
   
   # VerisoulSDK from GitHub
-  pod 'VerisoulSDK', :git => 'https://github.com/verisoul/ios-sdk.git', :tag => '0.4.69'
+  pod 'VerisoulSDK', :git => 'https://github.com/verisoul/ios-sdk.git', :tag => '0.4.70'
 
   use_react_native!(
     :path => config[:reactNativePath],

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1500,7 +1500,7 @@ PODS:
     - React-perflogger (= 0.77.0)
     - React-utils (= 0.77.0)
   - SocketRocket (0.7.1)
-  - verisoul-reactnative (0.4.69):
+  - verisoul-reactnative (0.4.71):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1520,9 +1520,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - VerisoulSDK (= 0.4.69)
+    - VerisoulSDK (= 0.4.70)
     - Yoga
-  - VerisoulSDK (0.4.69)
+  - VerisoulSDK (0.4.70)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -1594,7 +1594,7 @@ DEPENDENCIES:
   - ReactCodegen (from `build/generated/ios`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - verisoul-reactnative (from `../..`)
-  - VerisoulSDK (from `https://github.com/verisoul/ios-sdk.git`, tag `0.4.69`)
+  - VerisoulSDK (from `https://github.com/verisoul/ios-sdk.git`, tag `0.4.70`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -1737,14 +1737,14 @@ EXTERNAL SOURCES:
     :path: "../.."
   VerisoulSDK:
     :git: https://github.com/verisoul/ios-sdk.git
-    :tag: 0.4.69
+    :tag: 0.4.70
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 CHECKOUT OPTIONS:
   VerisoulSDK:
     :git: https://github.com/verisoul/ios-sdk.git
-    :tag: 0.4.69
+    :tag: 0.4.70
 
 SPEC CHECKSUMS:
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
@@ -1813,10 +1813,10 @@ SPEC CHECKSUMS:
   ReactCodegen: 58a974a1a86362975fd49596480c5f0f17ee06a2
   ReactCommon: e686c5766f0ebe5293be5a3957b833645cdac8ad
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  verisoul-reactnative: 93f7885470e82c3026ffd4bd7aec75520428ad2e
-  VerisoulSDK: 485cd13d1b5debfa2f5b4e4ec8b0b69e02a7631a
+  verisoul-reactnative: efc205e28d908dcc5f4cd60a81029ff1478497a0
+  VerisoulSDK: 792949d8db9f2257c81c416e427e5eacb58a10a5
   Yoga: c34725819ab0a5962e85455b9e56679b306910ee
 
-PODFILE CHECKSUM: 0cb62c8516f0bcd9abb5a3482fdcedc2ca1b68f7
+PODFILE CHECKSUM: 422099cb10e119241912b6688b7742e3a9ca87d0
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verisoul_ai/react-native-verisoul",
-  "version": "0.4.70",
+  "version": "0.4.71",
   "description": "Verisoul helps businesses stop fake accounts and fraud",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/verisoul-reactnative.podspec
+++ b/verisoul-reactnative.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/verisoul/react-native-sdk", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
-  s.dependency 'VerisoulSDK', '0.4.69'
+  s.dependency 'VerisoulSDK', '0.4.70'
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.


### PR DESCRIPTION
## Summary
- Bumps native `VerisoulSDK` iOS pin 0.4.69 -> 0.4.70, which fixes the crash reported by Debbie: the SDK's touch-capture overlay cleanup used `window.viewWithTag(100)`, which could remove a React-managed Fabric view (Fabric assigns sequential integer tags), corrupting Fabric's mounting state and crashing with `NSRangeException` in `-[RCTViewComponentView unmountChildComponentView:index:]` during view teardown.
- RN package version 0.4.70 -> 0.4.71 with CHANGELOG entry. Example Podfile pin updated. Android pin unchanged.

## Test plan
- [x] Reproduced the crash on `example-expo` (Fabric) with VerisoulSDK 0.4.69: React view with tag 100 was removed by the SDK on `configure()`, and unmounting its subtree crashed at `RCTViewComponentView.mm:154`
- [x] With 0.4.70: the same React tag-100 view keeps its superview after `configure()`/`reinitialize()`, the SDK overlay attaches untagged among the window's direct subviews, and the filler unmount completes with the app alive; no new crash reports
- [x] Session IDs obtained via configure -> reinitialize -> getSessionID and `/session/authenticate` returned 200 for all returned session IDs

Made with [Cursor](https://cursor.com)