### PR TITLE
chore: release 0.4.72 - recommend lazy SDK initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.4.72] - 2026-07-14
+
+### Changed
+- **Docs**: recommend calling `configure()` before you intend to retrieve a session_id — only initialize the SDK if you plan to call the Verisoul API for that session
+
 ## [0.4.71] - 2026-07-07
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ npx expo run:android  # or npx expo run:ios
 
 ### Initialize the SDK
 
-The `configure()` method initializes the Verisoul SDK with your project credentials. This method must be called once when your application starts.
+The `configure()` method initializes the Verisoul SDK with your project credentials. Call `configure()` before you intend to retrieve a Verisoul session_id — only initialize the SDK if you plan to call the Verisoul API for that session.
 
 **Parameters:**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verisoul_ai/react-native-verisoul",
-  "version": "0.4.71",
+  "version": "0.4.72",
   "description": "Verisoul helps businesses stop fake accounts and fraud",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",


### PR DESCRIPTION
## Summary

- README: recommend calling `configure()` before you intend to retrieve a Verisoul session_id — only initialize the SDK if you plan to call the Verisoul API for that session.
- Bump version to 0.4.72 + CHANGELOG entry (README-only release so the npm page picks up the new language).

No native pin changes and no code changes. Matches the docs site update (verisoul/docs#50) and the same change across the Android/iOS/Flutter READMEs.

## Release

After squash-merge: tag `v0.4.72` on `main` to publish to npm via the OIDC workflow (version matches tag — CI validates).

Made with [Cursor](https://cursor.com)