### PR TITLE
chore: release 0.4.73 — Android native 0.4.71 (DataStore corruption recovery)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.4.73] - 2026-07-14
+
+### Changed
+- **Android**: bump `ai.verisoul:android` to **0.4.71** — recovers from a corrupted DataStore preferences file ("Unable to parse preferences proto") that previously made `getSessionId()` fail permanently with `SESSION_UNAVAILABLE` on affected devices until app storage was cleared
+
 ## [0.4.72] - 2026-07-14
 
 ### Changed

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -104,7 +104,7 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  api "ai.verisoul:android:0.4.70"
+  api "ai.verisoul:android:0.4.71"
 
   // Unit test dependencies for deadlock demonstration tests
   testImplementation "junit:junit:4.13.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verisoul_ai/react-native-verisoul",
-  "version": "0.4.72",
+  "version": "0.4.73",
   "description": "Verisoul helps businesses stop fake accounts and fraud",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",


### PR DESCRIPTION
## Summary
- Bump `ai.verisoul:android` pin 0.4.70 → 0.4.71: recovers from a corrupted DataStore preferences file ("Unable to parse preferences proto") that made `getSessionId()` fail permanently with `SESSION_UNAVAILABLE` on affected devices (seen at ~100 Scrambly devices/day).
- iOS native pin unchanged (`VerisoulSDK 0.4.70`).

## Test plan
- [x] Native fix validated in native-android-sdk: regression test + emulator Repeat (10/10 200s) / Chaos (40 rounds, 0 failures) + on-device corrupted-file recovery e2e
- [x] Example app dependency resolution against published 0.4.71

Made with [Cursor](https://cursor.com)