### PR TITLE
Release 0.4.74 — bump native Android to 0.4.72 (VER-910 device telemetry)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.4.74] - 2026-07-23
+
+### Changed
+- **Android**: bump `ai.verisoul:android` to **0.4.72** — collects GPU renderer, CPU core count, and total device RAM in the `deviceData` telemetry payload (VER-910)
+
 ## [0.4.73] - 2026-07-14
 
 ### Changed

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -104,7 +104,7 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  api "ai.verisoul:android:0.4.71"
+  api "ai.verisoul:android:0.4.72"
 
   // Unit test dependencies for deadlock demonstration tests
   testImplementation "junit:junit:4.13.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verisoul_ai/react-native-verisoul",
-  "version": "0.4.73",
+  "version": "0.4.74",
   "description": "Verisoul helps businesses stop fake accounts and fraud",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",


### PR DESCRIPTION
## Summary
- Bumps `ai.verisoul:android` to **0.4.72**, which adds `cpuCores`, `totalRamBytes`, and `gpuRenderer` to the `deviceData` telemetry payload ([VER-910](https://linear.app/verisoul-eng/issue/VER-910/native-android-sdk-collect-gpu-renderer-cpu-core-count-and-total)).
- Releases `@verisoul_ai/react-native-verisoul` 0.4.74. iOS pin unchanged (0.4.70).

## Validation
- Example app builds against the published 0.4.72 artifact and ran Repeat (10/10) + Chaos (40/40) on an emulator with zero non-200 `/session/authenticate` responses.
- Spot-checked a session in sandbox Spanner `raw_android`: all three new fields present and correct.

Made with [Cursor](https://cursor.com)