### PR TITLE
chore: release 0.4.75 — bump ai.verisoul:android to 0.4.73 (VER-942 carrier identity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.4.75] - 2026-08-06
+
+### Changed
+- **Android**: bump `ai.verisoul:android` to **0.4.73** — collects carrier identity fields (`networkOperatorName`, `simOperatorName`, plus numeric MCC+MNC `networkOperator`/`simOperator`) without requiring the `READ_PHONE_STATE` permission (VER-942)
+
 ## [0.4.74] - 2026-07-23
 
 ### Changed

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -104,7 +104,7 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  api "ai.verisoul:android:0.4.72"
+  api "ai.verisoul:android:0.4.73"
 
   // Unit test dependencies for deadlock demonstration tests
   testImplementation "junit:junit:4.13.2"

--- a/example/src/testHarness.ts
+++ b/example/src/testHarness.ts
@@ -5,7 +5,7 @@ import { VERISOUL_ENV, VERISOUL_API_KEY } from '@env';
 const getApiBaseUrl = (env: string): string => {
   switch (env?.toLowerCase()) {
     case 'production':
-      return 'https://api.verisoul.ai';
+      return 'https://api.prod.verisoul.ai';
     case 'sandbox':
       return 'https://api.sandbox.verisoul.ai';
     case 'staging':

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verisoul_ai/react-native-verisoul",
-  "version": "0.4.74",
+  "version": "0.4.75",
   "description": "Verisoul helps businesses stop fake accounts and fraud",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",


### PR DESCRIPTION
## Summary
- Bump `ai.verisoul:android` pin to **0.4.73**, which collects carrier identity fields (`networkOperatorName`, `simOperatorName`, numeric `networkOperator`/`simOperator`) without requiring the `READ_PHONE_STATE` permission (VER-942)
- Bump package version to **0.4.75** + CHANGELOG entry (Android-only release; iOS `VerisoulSDK` pin stays at 0.4.70)
- Fix example test harness: production API base URL was `api.verisoul.ai`, which does not resolve — corrected to `api.prod.verisoul.ai`

## Validation
Ran the prod release gate on a physical device (Samsung SM-G7810, Android 13) with the example app built against native 0.4.73 from Artifact Registry, project `00000000-0000-0000-0000-000000000001` (production):
- Repeat test: 10/10 rounds → `/session/authenticate` 200, 0 failures
- Chaos test: 40/40 rounds (8 concurrent workers) → all 200, 0 failures, avg session latency 587 ms
- JS unit tests, typecheck, and Android module unit tests all pass

## Release (do not tag yet)
Publishing is triggered by the `v0.4.75` tag via GitHub Actions (`publish.yml`, npm OIDC). Holding off on merge/tag pending possible migration of the publish workflow to Cloud Build due to the GitHub Actions runner outage.

Made with [Cursor](https://cursor.com)