### PR TITLE
chore: release 0.4.76 — bump ai.verisoul:android to 0.4.74 (VER-944 SIM country fields)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.4.76] - 2026-08-06
+
+### Changed
+- **Android**: bump `ai.verisoul:android` to **0.4.74** — collects permission-free SIM country fields (`simCountryIso`, `networkCountryIso`) in the `networkData` payload (VER-944)
+
 ## [0.4.75] - 2026-08-06
 
 ### Changed

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -104,7 +104,7 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  api "ai.verisoul:android:0.4.73"
+  api "ai.verisoul:android:0.4.74"
 
   // Unit test dependencies for deadlock demonstration tests
   testImplementation "junit:junit:4.13.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verisoul_ai/react-native-verisoul",
-  "version": "0.4.75",
+  "version": "0.4.76",
   "description": "Verisoul helps businesses stop fake accounts and fraud",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",


### PR DESCRIPTION
## Summary
- Bumps native Android pin to `ai.verisoul:android:0.4.74`, which adds permission-free `simCountryIso` / `networkCountryIso` to the `networkData` payload ([VER-944](https://linear.app/verisoul-eng/issue/VER-944/android-sdk-collect-simcountryiso-networkcountryiso-permission-free)).
- Bumps package version to 0.4.76 + CHANGELOG.

## Test plan
- [x] Example app built against published native 0.4.74 (resolved from Artifact Registry) on Pixel 8 API 36 emulator
- [x] Both fields verified server-side in `raw_android.raw_json` for the example session (prod)
- [x] Repeat test 10/10 200s; Chaos test 40 rounds, 0 failures

Made with [Cursor](https://cursor.com)